### PR TITLE
fix(ci): inject real blob token into production build

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,10 +31,15 @@ jobs:
         run: |
           pnpm dlx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
+      # `vercel pull` writes the literal placeholder `[SENSITIVE]` for the
+      # Sensitive BLOB_READ_WRITE_TOKEN when it runs off-Vercel (in CI). Wrapping
+      # the build in `dotenvx run -f .env.production` injects the real decrypted
+      # token into the environment first, so the placeholder never reaches Payload
+      # (mirrors deploy-staging.yml).
       - name: Build Project Artifacts
         env:
           DOTENV_PRIVATE_KEY_PRODUCTION: ${{ secrets.DOTENV_PRIVATE_KEY_PRODUCTION }}
-        run: pnpm dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dotenvx run -f .env.production -- pnpm dlx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
         run: pnpm dlx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Production deploy failed at `next build` with `Invalid token format for Vercel Blob adapter`.

**Cause:** `BLOB_READ_WRITE_TOKEN` is a *Sensitive* env var in Vercel. When `vercel pull` runs off-Vercel (in CI), it writes the literal placeholder `[SENSITIVE]` instead of the real value. That placeholder shadowed the decrypted `.env.production` token and reached Payload as a malformed token.

**Fix:** wrap `vercel build --prod` in `dotenvx run -f .env.production` so the real decrypted token is set in the environment first — mirrors the now-green `deploy-staging.yml`.

Verified mechanism against the successful staging run (same error → green with the same wrapper).