### PR TITLE
fix(deps): pin pnpm@11.15.1 and align build-script approval config

### DIFF
--- a/.github/tooling/ci/format/action.yml
+++ b/.github/tooling/ci/format/action.yml
@@ -5,8 +5,6 @@ runs:
   steps:
     - name: 'Setup pnpm'
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: 'Setup Node'
       uses: actions/setup-node@v4

--- a/.github/tooling/ci/lint/action.yml
+++ b/.github/tooling/ci/lint/action.yml
@@ -5,8 +5,6 @@ runs:
   steps:
     - name: 'Setup pnpm'
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: 'Setup Node'
       uses: actions/setup-node@v4

--- a/.github/tooling/ci/typecheck/action.yml
+++ b/.github/tooling/ci/typecheck/action.yml
@@ -5,8 +5,6 @@ runs:
   steps:
     - name: 'Setup pnpm'
       uses: pnpm/action-setup@v4
-      with:
-        version: latest
 
     - name: 'Setup Node'
       uses: actions/setup-node@v4

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install pnpm (if necessary)
-        run: which pnpm || npm install -g pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@11.15.1",
   "scripts": {
     "build": "dotenvx run --convention=nextjs -- next build",
     "build:staging": "dotenvx run -f .env.development -- next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+# settings-only (no `packages:`) and `allowBuilds` require pnpm 11, pinned in package.json
 allowBuilds:
   '@tailwindcss/oxide': true
   esbuild: false


### PR DESCRIPTION
Closes #33

## What changed

- **`package.json`** — pin `"packageManager": "pnpm@11.15.1"` so every environment (GitHub Actions, Vercel, local) resolves the same pnpm instead of Vercel defaulting to pnpm@9 and Actions floating on `latest`.
- **`pnpm-workspace.yaml`** — keep the settings-only file valid for the pinned version: `allowBuilds` with real values (`sharp: true`, `'@tailwindcss/oxide': true`, `esbuild: false`).
- **`pnpm/action-setup` call sites (staging workflow + 3 CI composite actions)** — drop `version: latest`; the action reads the `packageManager` pin (specifying both is an error).
- **`deploy-production.yml`** — replace the ad-hoc `which pnpm || npm install -g pnpm` with `pnpm/action-setup@v4` so production also honors the pin.

## Deviation from the issue's proposed fix

The issue proposed replacing `allowBuilds` with `onlyBuiltDependencies`. Empirically, **pnpm 11 ignores `onlyBuiltDependencies`** (`ERR_PNPM_IGNORED_BUILDS`, all build scripts skipped) and scaffolds an `allowBuilds:` block itself — `allowBuilds` is the valid schema on the pinned version. The original file's key was right for v11; the real defects were the unpinned version (pnpm@9 on Vercel rejecting the settings-only file) and CI floating on `latest`.

## Verified locally on pnpm@11.15.1

- `pnpm install` succeeds; lockfile unchanged
- `sharp` and `@tailwindcss/oxide` install/postinstall scripts run
- `esbuild` stays un-built
- `pnpm typecheck` and `pnpm lint` pass

## Pending post-push verification

- [x] Vercel preview deployment succeeds on this branch (confirms Vercel honors the `packageManager` pin; if it still picks pnpm@9, set `ENABLE_EXPERIMENTAL_COREPACK=1` in Vercel project env)
- [x] CI lint/format/typecheck pass with pin-derived pnpm
