### PR TITLE
refactor: fuse rich-text fields with their HTML twins in one helper

### DIFF
--- a/src/blocks/Accordion/config.ts
+++ b/src/blocks/Accordion/config.ts
@@ -1,6 +1,5 @@
-import { lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { Block } from 'payload'
-import { richTextField } from '@/fields/richText'
+import { richTextWithHtmlField } from '@/fields/richText'
 
 export const Accordion: Block = {
   fields: [
@@ -13,15 +12,10 @@ export const Accordion: Block = {
           type: 'text',
           required: true,
         },
-        ...richTextField({
+        ...richTextWithHtmlField('content', {
           richTextOverrides: {
-            name: 'content',
             required: true,
           },
-        }),
-        lexicalHTMLField({
-          htmlFieldName: 'contentHTML',
-          lexicalFieldName: 'content',
         }),
       ],
     },

--- a/src/blocks/CallToAction/config.ts
+++ b/src/blocks/CallToAction/config.ts
@@ -1,8 +1,7 @@
-import { lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { Block } from 'payload'
 import { backgroundColorField } from '@/fields/backgroundColor'
 import { linkGroup } from '@/fields/linkGroup'
-import { richTextField } from '@/fields/richText'
+import { richTextWithHtmlField } from '@/fields/richText'
 
 export const CallToAction: Block = {
   fields: [
@@ -20,15 +19,7 @@ export const CallToAction: Block = {
       name: 'subheading',
       type: 'text',
     },
-    ...richTextField({
-      richTextOverrides: {
-        name: 'body',
-      },
-    }),
-    lexicalHTMLField({
-      htmlFieldName: 'bodyHTML',
-      lexicalFieldName: 'body',
-    }),
+    ...richTextWithHtmlField('body'),
     linkGroup({
       appearances: false,
       overrides: { maxRows: 2 },

--- a/src/blocks/ImageWithText/config.ts
+++ b/src/blocks/ImageWithText/config.ts
@@ -1,7 +1,6 @@
-import { lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { Block } from 'payload'
 import { backgroundColorField } from '@/fields/backgroundColor'
-import { richTextField } from '@/fields/richText'
+import { richTextWithHtmlField } from '@/fields/richText'
 
 export const ImageWithText: Block = {
   fields: [
@@ -42,16 +41,12 @@ export const ImageWithText: Block = {
             { label: 'Accordion', value: 'accordion' },
           ],
         },
-        ...richTextField({
+        ...richTextWithHtmlField('richText', {
           richTextOverrides: {
             admin: {
               condition: (_, siblingData) => siblingData.contentType === 'text',
             },
           },
-        }),
-        lexicalHTMLField({
-          htmlFieldName: 'richTextHTML',
-          lexicalFieldName: 'richText',
         }),
         {
           admin: {
@@ -67,15 +62,7 @@ export const ImageWithText: Block = {
               type: 'text',
               required: true,
             },
-            ...richTextField({
-              richTextOverrides: {
-                name: 'accordionContent',
-              },
-            }),
-            lexicalHTMLField({
-              htmlFieldName: 'accordionContentHTML',
-              lexicalFieldName: 'accordionContent',
-            }),
+            ...richTextWithHtmlField('accordionContent'),
           ],
         },
       ],

--- a/src/collections/Testimonials/index.ts
+++ b/src/collections/Testimonials/index.ts
@@ -1,8 +1,7 @@
-import { lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { CollectionConfig } from 'payload'
 import { anyone } from '@/access/anyone'
 import { authenticated } from '@/access/authenticated'
-import { richTextField } from '@/fields/richText'
+import { richTextWithHtmlField } from '@/fields/richText'
 
 export const Testimonials: CollectionConfig = {
   access: {
@@ -24,11 +23,7 @@ export const Testimonials: CollectionConfig = {
       name: 'dateRange',
       type: 'text',
     },
-    ...richTextField({ richTextOverrides: { name: 'testimonial' } }),
-    lexicalHTMLField({
-      htmlFieldName: 'testimonialHTML',
-      lexicalFieldName: 'testimonial',
-    }),
+    ...richTextWithHtmlField('testimonial'),
   ],
   slug: 'testimonials',
 }

--- a/src/fields/richText/index.ts
+++ b/src/fields/richText/index.ts
@@ -1,11 +1,10 @@
 import type {
-  FeatureProviderServer,
   LexicalEditorProps,
   LexicalRichTextAdapter,
 } from '@payloadcms/richtext-lexical'
-import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import { lexicalEditor, lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { SerializedEditorState } from 'lexical'
-import type { RichTextField } from 'payload'
+import type { Field, RichTextField } from 'payload'
 import { deepMerge } from 'payload'
 
 type LexicalRichTextField = RichTextField<
@@ -14,33 +13,33 @@ type LexicalRichTextField = RichTextField<
   LexicalEditorProps
 >
 
-export type RichTextFieldOverrides = {
-  richTextOverrides?: Partial<LexicalRichTextField>
+type RichTextWithHtmlFieldOptions = {
+  richTextOverrides?: Partial<Omit<LexicalRichTextField, 'name'>>
 }
 
-type RichText = (
-  overrides?: RichTextFieldOverrides,
-  additions?: {
-    features?: FeatureProviderServer[]
+export const richTextWithHtmlField = (
+  name: string,
+  options: RichTextWithHtmlFieldOptions = {}
+): [LexicalRichTextField, Field] => {
+  const richText = {
+    ...deepMerge<LexicalRichTextField>(
+      {
+        editor: lexicalEditor({
+          features: ({ defaultFeatures }) => defaultFeatures,
+        }),
+        name,
+        type: 'richText',
+      },
+      options.richTextOverrides ?? {}
+    ),
+    name,
   }
-) => [RichTextField]
 
-export const richTextField: RichText = (overrides = {}, additions = {}) => {
-  const { richTextOverrides = {} } = overrides
-
-  const field = deepMerge<LexicalRichTextField>(
-    {
-      editor: lexicalEditor({
-        features: ({ defaultFeatures }) => [
-          ...defaultFeatures,
-          ...(additions.features ?? []),
-        ],
-      }),
-      name: 'richText',
-      type: 'richText',
-    },
-    richTextOverrides
-  )
-
-  return [field]
+  return [
+    richText,
+    lexicalHTMLField({
+      htmlFieldName: `${name}HTML`,
+      lexicalFieldName: name,
+    }),
+  ]
 }

--- a/src/globals/footer/config.ts
+++ b/src/globals/footer/config.ts
@@ -1,7 +1,6 @@
-import { lexicalHTMLField } from '@payloadcms/richtext-lexical'
 import type { GlobalConfig } from 'payload'
 import { link } from '@/fields/link'
-import { richTextField } from '@/fields/richText'
+import { richTextWithHtmlField } from '@/fields/richText'
 
 export const Footer: GlobalConfig = {
   fields: [
@@ -71,15 +70,7 @@ export const Footer: GlobalConfig = {
                   name: 'termsOfServiceSubheading',
                   type: 'text',
                 },
-                ...richTextField({
-                  richTextOverrides: {
-                    name: 'termsOfService',
-                  },
-                }),
-                lexicalHTMLField({
-                  htmlFieldName: 'termsOfServiceHTML',
-                  lexicalFieldName: 'termsOfService',
-                }),
+                ...richTextWithHtmlField('termsOfService'),
               ],
               label: 'Terms of Service',
               type: 'group',
@@ -100,15 +91,7 @@ export const Footer: GlobalConfig = {
                   name: 'privacyPolicySubheading',
                   type: 'text',
                 },
-                ...richTextField({
-                  richTextOverrides: {
-                    name: 'privacyPolicy',
-                  },
-                }),
-                lexicalHTMLField({
-                  htmlFieldName: 'privacyPolicyHTML',
-                  lexicalFieldName: 'privacyPolicy',
-                }),
+                ...richTextWithHtmlField('privacyPolicy'),
               ],
               label: 'Privacy Policy',
               type: 'group',
@@ -129,15 +112,7 @@ export const Footer: GlobalConfig = {
                   name: 'disclaimerSubheading',
                   type: 'text',
                 },
-                ...richTextField({
-                  richTextOverrides: {
-                    name: 'disclaimer',
-                  },
-                }),
-                lexicalHTMLField({
-                  htmlFieldName: 'disclaimerHTML',
-                  lexicalFieldName: 'disclaimer',
-                }),
+                ...richTextWithHtmlField('disclaimer'),
               ],
               label: 'Disclaimer',
               type: 'group',


### PR DESCRIPTION
Closes #35

## What changed

- `richTextWithHtmlField(name, options?)` in `src/fields/richText` emits both the Lexical field and its `<name>HTML` twin from a single name argument. `richTextOverrides` is typed `Partial<Omit<…, 'name'>>` and `name` is re-asserted after the merge, so an override can never desync the pairing — not even through a cast.
- All 8 hand-paired `lexicalHTMLField` call sites migrated (blocks Accordion, CallToAction, ImageWithText ×2 incl. the nested accordion content; footer global ×3; Testimonials). No `lexicalHTMLField` usage remains outside the helper module.
- The old standalone `richTextField` and its unused `features` addition had zero remaining callers — every call site was one of the twin pairs — so they were folded into the helper rather than kept as dead public API.

## Verification

- `generate:types` can't run locally (dotenvx-encrypted env), so types-unchanged was verified one level stronger: a normalized deep-compare of the emitted config objects (`Accordion`, `CallToAction`, `ImageWithText`, `Footer`, `Testimonials`) between `origin/dev` and this branch is **byte-identical** (671-line dump, 57 named fields, all 8 HTML twins present). Identical configs ⟹ identical generated types.
- `tsc --noEmit`, `biome lint`, `biome format`, and `next build --experimental-build-mode compile` all pass.
- Reader components are untouched and read the same twin names; "renders identically" is best eyeballed on the Vercel preview.