### PR TITLE
refactor: move rich-text emptiness behind the RichText seam

### DIFF
--- a/src/blocks/CallToAction/call-to-action.tsx
+++ b/src/blocks/CallToAction/call-to-action.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import type { FC } from 'react'
-import { RichText } from '@/components/rich-text'
+import { isRichTextEmpty, RichText } from '@/components/rich-text'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/utils/cn'
 import type { CallToActionBlock } from '@/types/payload-types'
@@ -14,7 +14,6 @@ type Props = CallToActionBlock
 const CallToAction: FC<Props> = ({
   backgroundColor,
   backgroundImage,
-  body,
   bodyHTML,
   heading,
   links,
@@ -23,16 +22,7 @@ const CallToAction: FC<Props> = ({
   const bgColor = mapBackgroundColor(backgroundColor)
   const bgImage = getImage(backgroundImage)
 
-  const hasBody =
-    body &&
-    Array.isArray(body?.root?.children) &&
-    body.root.children.length > 0 &&
-    (
-      body.root.children[0]?.children as {
-        type: string
-        children: { type: string }[]
-      }[]
-    ).length > 0
+  const hasBody = !isRichTextEmpty(bodyHTML)
 
   return (
     <section
@@ -53,7 +43,7 @@ const CallToAction: FC<Props> = ({
               </span>
             )}
           </div>
-          {hasBody && bodyHTML && (
+          {hasBody && (
             <div className="max-w-prose">
               <RichText content={bodyHTML} />
             </div>

--- a/src/components/rich-text.tsx
+++ b/src/components/rich-text.tsx
@@ -4,10 +4,28 @@ import { type ComponentPropsWithoutRef, forwardRef } from 'react'
 
 import { cn } from '@/utils/cn'
 
-type RichTextProps = ComponentPropsWithoutRef<'div'> & {
+type RichTextProps = Omit<ComponentPropsWithoutRef<'div'>, 'content'> & {
   asChild?: boolean
-  content?: string
+  content?: string | null
   inline?: boolean
+}
+
+// void/embed elements are visible content despite contributing no text
+const MEDIA_TAG = /<(img|hr|iframe|video|audio|embed|object|svg)\b/i
+
+const isRichTextEmpty = (content?: string | null): boolean => {
+  if (!content) {
+    return true
+  }
+  if (MEDIA_TAG.test(content)) {
+    return false
+  }
+  return (
+    content
+      .replace(/<[^>]*>/g, '')
+      .replaceAll('&nbsp;', '')
+      .trim() === ''
+  )
 }
 
 const resolveContent = (value: string, inline: boolean): string => {
@@ -37,4 +55,4 @@ const RichText = forwardRef<HTMLDivElement, RichTextProps>(
 )
 RichText.displayName = 'RichText'
 
-export { RichText, type RichTextProps }
+export { isRichTextEmpty, RichText, type RichTextProps }


### PR DESCRIPTION
Closes #38

## What changed

- `isRichTextEmpty(content)`, exported beside `RichText`, decides emptiness from the HTML twin: falsy → empty; media/void tags (`img`, `hr`, `iframe`, …) → content; otherwise strip tags + `&nbsp;` and test for residual text. CallToAction's four-level Lexical spelunk (and its hand-written `as` cast) is gone — `hasBody = !isRichTextEmpty(bodyHTML)` and `body` is no longer even destructured.
- `RichText`'s `content` prop now honestly accepts the CMS's `string | null` (it already rendered nothing for falsy). That required `Omit`-ing the native div `content` metadata attribute React's `HTMLAttributes` declares, which was silently swallowing the `| null`.

## Behavioral notes (from review)

Three divergences, all improvements or invisible:
1. `<p></p><p>text</p>` — the old check only inspected the **first** paragraph and wrongly dropped the body; now it renders.
2. Whitespace/`&nbsp;`-only body — old rendered an effectively blank wrapper; now renders nothing.
3. The old cast would have **thrown at runtime** on a childless first node (e.g. an upload node first); the media-tag path handles that correctly.

## Verification

- 14-case behavioral check of the predicate (empty/whitespace/nbsp paragraphs, text, headings, lists, links, image-only, hr-only) — all pass.
- `tsc --noEmit`, `biome lint`, `biome format`, `next build --experimental-build-mode compile` all pass.
- Two-axis review against `origin/dev`: zero hard violations (the diff removes a pre-existing `as`-cast violation), all four acceptance criteria verified.