### PR TITLE
refactor: single source of truth for the background-color palette; fix link-field dead code

### DIFF
--- a/src/fields/backgroundColor/index.ts
+++ b/src/fields/backgroundColor/index.ts
@@ -1,5 +1,6 @@
 import type { SelectField } from 'payload'
 import { deepMerge } from 'payload'
+import { BACKGROUND_COLOR_PALETTE } from '@/utils/mapBackgroundColor'
 
 type BackgroundColorField = (overrides?: Partial<SelectField>) => [SelectField]
 
@@ -8,28 +9,9 @@ export const backgroundColorField: BackgroundColorField = (overrides = {}) => {
     {
       name: 'backgroundColor',
       type: 'select',
-      options: [
-        {
-          label: 'Teal',
-          value: 'brand-primary',
-        },
-        {
-          label: 'Green',
-          value: 'brand-secondary',
-        },
-        {
-          label: 'Yellow',
-          value: 'brand-tertiary',
-        },
-        {
-          label: 'Orange',
-          value: 'brand-quaternary',
-        },
-        {
-          label: 'None',
-          value: 'transparent',
-        },
-      ],
+      options: Object.entries(BACKGROUND_COLOR_PALETTE).map(
+        ([value, { label }]) => ({ label, value })
+      ),
     },
     overrides
   )

--- a/src/fields/link/index.ts
+++ b/src/fields/link/index.ts
@@ -75,12 +75,13 @@ export const link: LinkType = ({
     name: 'link',
   }
 
-  const linkTypes: Field[] = [
+  const buildLinkTypeFields = (width?: string): Field[] => [
     {
       name: 'reference',
       type: 'relationship',
       admin: {
         condition: (_, siblingData) => siblingData?.type === 'reference',
+        width,
       },
       label: 'Document to link to',
       relationTo: ['pages'],
@@ -91,6 +92,7 @@ export const link: LinkType = ({
       type: 'text',
       admin: {
         condition: (_, siblingData) => siblingData?.type === 'custom',
+        width,
       },
       label: 'Custom URL',
       required: true,
@@ -98,20 +100,12 @@ export const link: LinkType = ({
   ]
 
   if (disableLabel) {
-    linkResult.fields = [...linkResult.fields, ...linkTypes]
+    linkResult.fields = [...linkResult.fields, ...buildLinkTypeFields()]
   } else {
-    linkTypes.map((linkType) => ({
-      ...linkType,
-      admin: {
-        ...linkType.admin,
-        width: '50%',
-      },
-    }))
-
     linkResult.fields.push({
       type: 'row',
       fields: [
-        ...linkTypes,
+        ...buildLinkTypeFields('50%'),
         {
           name: 'label',
           type: 'text',

--- a/src/utils/mapBackgroundColor.ts
+++ b/src/utils/mapBackgroundColor.ts
@@ -1,22 +1,18 @@
-import { match } from 'ts-pattern'
+export const BACKGROUND_COLOR_PALETTE = {
+  'brand-primary': { className: 'bg-brand-primary', label: 'Teal' },
+  'brand-secondary': { className: 'bg-brand-secondary', label: 'Green' },
+  'brand-tertiary': { className: 'bg-brand-tertiary', label: 'Yellow' },
+  'brand-quaternary': { className: 'bg-brand-quaternary', label: 'Orange' },
+  transparent: { className: 'bg-transparent', label: 'None' },
+} as const satisfies Record<string, { className: string; label: string }>
 
-type BackgroundColor =
-  | (
-      | 'brand-primary'
-      | 'brand-secondary'
-      | 'brand-tertiary'
-      | 'brand-quaternary'
-      | 'transparent'
-    )
-  | null
-  | undefined
+export type BackgroundColor = keyof typeof BACKGROUND_COLOR_PALETTE
 
-export function mapBackgroundColor(color: BackgroundColor) {
-  return match(color)
-    .with('brand-primary', () => 'bg-brand-primary')
-    .with('brand-secondary', () => 'bg-brand-secondary')
-    .with('brand-tertiary', () => 'bg-brand-tertiary')
-    .with('brand-quaternary', () => 'bg-brand-quaternary')
-    .with('transparent', () => 'bg-transparent')
-    .otherwise(() => 'bg-transparent')
+export function mapBackgroundColor(
+  color: BackgroundColor | null | undefined
+): string {
+  if (color && color in BACKGROUND_COLOR_PALETTE) {
+    return BACKGROUND_COLOR_PALETTE[color].className
+  }
+  return BACKGROUND_COLOR_PALETTE.transparent.className
 }


### PR DESCRIPTION
Closes #39

## What changed

- `BACKGROUND_COLOR_PALETTE` (value → admin label + `bg-*` class) in `src/utils/mapBackgroundColor.ts` is now the single palette record. The CMS select options derive from its entries, `mapBackgroundColor` indexes it (with the old `bg-transparent` fallback for null/stale values, now itself read from the record), and `BackgroundColor` is `keyof` the record — adding a color is a one-record change. It lives in the client-safe utils module (not the field module) so `payload` never enters a client bundle; the field config imports from utils.
- **Link-field dead code fixed**: the `disableLabel === false` branch mapped the link types to add 50% admin widths and discarded the result. Spreading the `Field` union un-narrows its discriminant — almost certainly why the assignment was dropped originally — so the two fields are now built by a `buildLinkTypeFields(width?)` factory with the width inline, which typechecks cleanly. The Payload admin's labeled link row now actually lays out reference/URL at 50% width.

## Verification

- Runtime dump comparison of `backgroundColorField()`, `mapBackgroundColor` (all five values + null/undefined/stale), and both `link()` variants vs `origin/dev`: the **only** difference is the two intended `width: '50%'` entries. Option order, labels, values, and class strings byte-identical.
- `tsc --noEmit`, `biome lint`, `biome format`, `next build --experimental-build-mode compile` all pass.
- Two-axis review against `origin/dev`: zero hard violations, all four acceptance criteria verified, no scope creep. `bg-*` literals remain verbatim in source so Tailwind's scanner keeps emitting them.