### PR TITLE
refactor: one owner for Page queries and the slug-to-path rule

### DIFF
--- a/src/app/(app)/(pages)/[slug]/page.tsx
+++ b/src/app/(app)/(pages)/[slug]/page.tsx
@@ -1,18 +1,16 @@
-import config from '@payload-config'
 import type { Metadata } from 'next'
-import { draftMode } from 'next/headers'
 import { notFound } from 'next/navigation'
-import { getPayload } from 'payload'
 import type { FC } from 'react'
-import { cache } from 'react'
 import { RenderBlocks } from '@/blocks/RenderBlocks/render-blocks'
+import { getPage, getPublishedPages } from '@/queries/pages'
+import { HOME_SLUG, isHomeSlug } from '@/utils/pageToPath'
 
 type Props = {
   params: Promise<{ slug: string }>
 }
 
 const Page: FC<Props> = async ({ params }) => {
-  const { slug = 'home' } = await params
+  const { slug = HOME_SLUG } = await params
   const page = await getPage(slug)
 
   if (!page) {
@@ -30,54 +28,18 @@ const Page: FC<Props> = async ({ params }) => {
 
 export default Page
 
-const getPage = cache(async (slug: string) => {
-  const payload = await getPayload({ config })
-  const { isEnabled: draft } = await draftMode()
-
-  const response = await payload.find({
-    collection: 'pages',
-    draft,
-    limit: 1,
-    pagination: false,
-    overrideAccess: draft,
-    where: {
-      slug: {
-        equals: slug,
-      },
-    },
-  })
-
-  return response.docs[0]
-})
-
-const getPages = cache(async () => {
-  const payload = await getPayload({ config })
-  const response = await payload.find({
-    collection: 'pages',
-    draft: false,
-    limit: 100,
-    overrideAccess: false,
-    pagination: false,
-    select: {
-      slug: true,
-    },
-  })
-
-  return response.docs
-})
-
 export async function generateStaticParams() {
-  const pages = await getPages()
+  const pages = await getPublishedPages()
 
   return pages
-    .filter((page) => page.slug !== 'home')
+    .filter((page) => !isHomeSlug(page.slug))
     .map(({ slug }) => {
       return { slug }
     })
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug = 'home' } = await params
+  const { slug = HOME_SLUG } = await params
   const page = await getPage(slug)
 
   if (!page?.meta) {

--- a/src/app/(app)/sitemap.ts
+++ b/src/app/(app)/sitemap.ts
@@ -1,22 +1,11 @@
-import config from '@payload-config'
 import type { MetadataRoute } from 'next'
-import { getPayload, type PaginatedDocs } from 'payload'
-import type { Page } from '@/types/payload-types'
+import { getPublishedPages } from '@/queries/pages'
 import { getServerSideURL } from '@/utils/getURL'
+import { isHomeSlug, pageToPath } from '@/utils/pageToPath'
 
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
-  const payload = await getPayload({ config })
-
   try {
-    const pages: PaginatedDocs<Page> = await payload.find({
-      collection: 'pages',
-      limit: 0,
-      where: {
-        _status: {
-          equals: 'published',
-        },
-      },
-    })
+    const pages = await getPublishedPages()
 
     const url = getServerSideURL()
 
@@ -72,14 +61,14 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
     })
 
     // Add dynamic pages from CMS
-    for (const { slug, updatedAt } of pages.docs) {
+    for (const { slug, updatedAt } of pages) {
       // Skip if slug is null/undefined or if it's the home page (handled separately)
-      if (!slug || slug === 'home') {
+      if (!slug || isHomeSlug(slug)) {
         continue
       }
 
       sitemapEntries.push({
-        url: `${url}/${slug}`,
+        url: `${url}${pageToPath(slug)}`,
         lastModified: new Date(updatedAt),
         changeFrequency: getChangeFrequency(slug),
         priority: getPriority(slug),

--- a/src/collections/Pages/hooks/revalidatePage.ts
+++ b/src/collections/Pages/hooks/revalidatePage.ts
@@ -5,6 +5,7 @@ import type {
 } from 'payload'
 
 import type { Page } from '@/types/payload-types'
+import { pageToPath } from '@/utils/pageToPath'
 
 export const revalidatePage: CollectionAfterChangeHook<Page> = ({
   doc,
@@ -13,7 +14,7 @@ export const revalidatePage: CollectionAfterChangeHook<Page> = ({
 }) => {
   if (!context.disableRevalidate) {
     if (doc._status === 'published') {
-      const path = doc.slug === 'home' ? '/' : `/${doc.slug}`
+      const path = pageToPath(doc.slug)
 
       payload.logger.info(`Revalidating page at path: ${path}`)
 
@@ -23,7 +24,7 @@ export const revalidatePage: CollectionAfterChangeHook<Page> = ({
 
     // If the page was previously published, we need to revalidate the old path
     if (previousDoc?._status === 'published' && doc._status !== 'published') {
-      const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
+      const oldPath = pageToPath(previousDoc.slug)
 
       payload.logger.info(`Revalidating old page at path: ${oldPath}`)
 
@@ -39,7 +40,7 @@ export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({
   req: { context },
 }) => {
   if (!context.disableRevalidate) {
-    const path = doc?.slug === 'home' ? '/' : `/${doc?.slug}`
+    const path = pageToPath(doc?.slug)
     revalidatePath(path)
     revalidateTag('pages-sitemap')
   }

--- a/src/queries/pages.ts
+++ b/src/queries/pages.ts
@@ -1,0 +1,47 @@
+import config from '@payload-config'
+import { draftMode } from 'next/headers'
+import { getPayload } from 'payload'
+import { cache } from 'react'
+
+export const getPage = cache(async (slug: string) => {
+  const payload = await getPayload({ config })
+  const { isEnabled: draft } = await draftMode()
+
+  const response = await payload.find({
+    collection: 'pages',
+    draft,
+    limit: 1,
+    pagination: false,
+    overrideAccess: draft,
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+  })
+
+  return response.docs[0]
+})
+
+export const getPublishedPages = cache(async () => {
+  const payload = await getPayload({ config })
+
+  const response = await payload.find({
+    collection: 'pages',
+    draft: false,
+    limit: 0,
+    overrideAccess: false,
+    pagination: false,
+    select: {
+      slug: true,
+      updatedAt: true,
+    },
+    where: {
+      _status: {
+        equals: 'published',
+      },
+    },
+  })
+
+  return response.docs
+})

--- a/src/utils/pageToPath.ts
+++ b/src/utils/pageToPath.ts
@@ -1,0 +1,9 @@
+export const HOME_SLUG = 'home'
+
+export function isHomeSlug(slug: string | null | undefined): boolean {
+  return slug === HOME_SLUG
+}
+
+export function pageToPath(slug: string | null | undefined): string {
+  return isHomeSlug(slug) ? '/' : `/${slug}`
+}

--- a/src/utils/resolveCmsLink.ts
+++ b/src/utils/resolveCmsLink.ts
@@ -1,5 +1,6 @@
 import { match, P } from 'ts-pattern'
 import type { Link } from '@/types/payload-types'
+import { pageToPath } from './pageToPath'
 
 export type ResolvedCmsLink = {
   href: string
@@ -22,7 +23,7 @@ export function resolveCmsLink(
         },
       },
       ({ reference: { value }, label, newTab }) => ({
-        href: value.slug === 'home' ? '/' : `/${value.slug}`,
+        href: pageToPath(value.slug),
         label: label ?? value.title,
         newTab: newTab ?? false,
       })


### PR DESCRIPTION
Closes #41

## What changed

- **`src/utils/pageToPath.ts`** (pure, client-safe) owns the routing invariant: `HOME_SLUG`, `isHomeSlug`, and `pageToPath`. All five former sites of the `home → '/'` rule use it (link resolution, revalidate hook ×3, sitemap URL building), and the home-identity checks in the sitemap skip, static-params filter, and the route's param defaults all reference the same constant — `grep "'home'"` outside this module now only hits the sitemap's SEO priority tables, which key several well-known slugs and aren't the routing rule.
- **`src/queries/pages.ts`** owns the Payload queries with React `cache()`: `getPage` (moved verbatim from the page route, same draft handling) and `getPublishedPages` (unifies the sitemap's find and the route's `getPages`: `_status: published`, `draft: false`, `limit: 0`, `overrideAccess: false`, `select: slug + updatedAt`). The page route, static params, and sitemap all consume this one query, so sitemap URLs and static params cannot drift.
- The pure/server two-file split mirrors the CmsLink precedent: `pageToPath` is imported by `resolveCmsLink` on the client side, so it cannot live with the `@payload-config` import.

## Deliberate behavior deltas (both fix the drift the issue describes)

1. **Static params**: the old `getPages` had no published filter and a `limit: 100` cap — never-published drafts were prerendered. Now published-only, uncapped. Draft pages still render on demand via `getPage` (`dynamicParams` default), so routing is unchanged.
2. **Sitemap failure mode**: `getPayload` moved inside the try (via the query module), so a connection failure now returns the single-entry fallback sitemap instead of throwing.

Pages `access.read` is `anyone`, so dropping the sitemap's default `overrideAccess: true` changes nothing.

## Verification

- `tsc`, `biome lint`, `biome format`, compile-mode `next build` all pass.
- Two-axis review against `origin/dev`: zero hard violations; spec verdict "substantially faithful" with both deltas above judged intended (and now documented here as requested). The reviewers' shared finding — the home-identity check still duplicated at two sites — was fixed with `isHomeSlug`/`HOME_SLUG` before this PR.